### PR TITLE
Make all the 'INSERT or REPLACE' SQL operations run in a transaction -

### DIFF
--- a/gnus-harvest.el
+++ b/gnus-harvest.el
@@ -273,6 +273,8 @@ VALUES
                       (throw 'found t))))
               (cdr info))))
        email-list))
+    (with-current-buffer tmp-buf
+      (insert "BEGIN;"))
     (mapc
      #'(lambda (info)
          (when info
@@ -293,6 +295,7 @@ VALUES
               (cdr info)))))
      email-list)
     (with-current-buffer tmp-buf
+      (insert "COMMIT;")
       (gnus-harvest-sqlite-invoke nil t)
       (kill-buffer (current-buffer)))))
 


### PR DESCRIPTION
this is a big performance increase even if there are only a moderate
number of addresses to add or update.
