### PR TITLE
gnus-harvest-addresses: Ensure that harvesting runs in the article buffer.

### DIFF
--- a/gnus-harvest.el
+++ b/gnus-harvest.el
@@ -257,6 +257,12 @@ VALUES
 ;;;###autoload
 (defun gnus-harvest-addresses ()
   "Harvest and remember the addresses in the current article buffer."
+
+  ;; Ensure that we are looking at the article rather than summary
+  ;; buffer.
+  (when (derived-mode-p 'gnus-summary-mode)
+    (set-buffer gnus-article-buffer))
+  
   (let ((tmp-buf (generate-new-buffer "*gnus harvest*"))
         (moment (number-to-string (floor (float-time))))
         (email-list


### PR DESCRIPTION
gnus-article-prepare-hook runs in the summary buffer, but gnus-harvest-addresses expects to run in the article buffer. Make it so.
